### PR TITLE
Fixed namespace issue by adding argument "null" to each callModule 

### DIFF
--- a/data_selection.R
+++ b/data_selection.R
@@ -110,15 +110,7 @@ plot_data_select <- function(input, output, session, dat, main_char_str, plot_ou
         droplevels.data.frame(.)
     }
     
-    
-    
-    
-    
-    
-    
-   
-    
-    
+
   })
 
 }  

--- a/drop_down_menus.R
+++ b/drop_down_menus.R
@@ -50,7 +50,7 @@ main_select_ui <- function(id) {
 
 main_select_server <- function(input, output, session, dat){
   
-  
+  ns <- session$ns
   output$main_menu <- renderUI({
     
     pickerInput(ns("main_select"),

--- a/server.R
+++ b/server.R
@@ -18,25 +18,25 @@ shinyServer(function (input,output){
   tab_tot_dat <- callModule(league_data_select, "uncer_select", 
                             dat = tot_dat, main_char_str = main_char_str)
   
-  plot_tar_dat <- callModule(plot_data_select, dat = tar_dat, 
+  plot_tar_dat <- callModule(plot_data_select, "null", dat = tar_dat, 
                              main_char_str = main_char_str, plot_outcome = plot_outcome)
-  plot_tot_dat <- callModule(plot_data_select, dat = tot_dat, 
+  plot_tot_dat <- callModule(plot_data_select, "null", dat = tot_dat, 
                              main_char_str = main_char_str, plot_outcome = plot_outcome)
   
-  plot_height <- callModule(plot_height_server,  plot_dat = plot_tar_dat)
+  plot_height <- callModule(plot_height_server, "null", plot_dat = plot_tar_dat)
   
-  plot_tar_nest <- callModule(plot_nest_server, plot_dat = plot_tar_dat, plot_outcome = plot_outcome) 
-  plot_tot_nest <- callModule(plot_nest_server, plot_dat = plot_tot_dat, plot_outcome = plot_outcome) 
+  plot_tar_nest <- callModule(plot_nest_server, "null", plot_dat = plot_tar_dat, plot_outcome = plot_outcome) 
+  plot_tot_nest <- callModule(plot_nest_server, "null", plot_dat = plot_tot_dat, plot_outcome = plot_outcome) 
   
   callModule(plot_tar_render, "plot_tar", plot_height = plot_height,
              dat = plot_tar_nest)
   callModule(plot_tot_render, "plot_tot",plot_height = plot_height, 
              dat = plot_tot_nest)
   
-  callModule(plot_scatter_server, "plot_cep", plot_dat = plot_tar_dat)
+#  callModule(plot_scatter_server, "plot_cep", plot_dat = plot_tar_dat)
   
-  tar_league_table <- callModule(table_server, dat = tab_tar_dat, uncer_ind = uncer_ind)
-  tot_league_table <- callModule(table_server, dat = tab_tot_dat, uncer_ind = uncer_ind)
+  tar_league_table <- callModule(table_server, "null", dat = tab_tar_dat, uncer_ind = uncer_ind)
+  tot_league_table <- callModule(table_server, "null", dat = tab_tot_dat, uncer_ind = uncer_ind)
   
   callModule(table_render, "table_tar", tar_league_table)
   callModule(table_render, "table_tot", tot_league_table)


### PR DESCRIPTION
Also fixed code in drop_down_menus script, we had removed (in error) the code which got the namespace from the session argument in the server side of the main_select_server module